### PR TITLE
Cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actix-http = "*" # Whatever matches with actix-web
 actix-web = "2.0.0"
+actix-service = "*" # Whatever matches with actix-web
 coi = "0.8.0"
 futures = "0.3.4"
 log = "0.4.8"
@@ -20,3 +22,6 @@ coi-actix-web-derive = { path = "coi-actix-web-derive", version = "0.1.0" }
 [features]
 default = []
 debug = ["coi/debug"]
+
+[patch.crates-io]
+coi = { path = "../coi", version = "0.8.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 
 [dependencies]
 actix-http = "*" # Whatever matches with actix-web
-actix-web = "2.0.0"
+actix-web = "2.0"
 actix-service = "*" # Whatever matches with actix-web
-coi = "0.8.0"
+coi = "0.9.0"
 futures = "0.3.4"
 log = "0.4.8"
 coi-actix-web-derive = { path = "coi-actix-web-derive", version = "0.1.0" }
@@ -22,6 +22,3 @@ coi-actix-web-derive = { path = "coi-actix-web-derive", version = "0.1.0" }
 [features]
 default = []
 debug = ["coi/debug"]
-
-[patch.crates-io]
-coi = { path = "../coi", version = "0.8.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coi-actix-web"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Paul Daniel Faria <Nashenas88@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,10 +14,10 @@ readme = "README.md"
 actix-http = "*" # Whatever matches with actix-web
 actix-web = "2.0"
 actix-service = "*" # Whatever matches with actix-web
-coi = "0.9.0"
+coi = "0.9.1"
 futures = "0.3.4"
 log = "0.4.8"
-coi-actix-web-derive = { path = "coi-actix-web-derive", version = "0.1.0" }
+coi-actix-web-derive = { path = "coi-actix-web-derive", version = "0.2.0" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ coi-actix-web-derive = { path = "coi-actix-web-derive", version = "0.1.0" }
 [features]
 default = []
 debug = ["coi/debug"]
+
+[dev-dependencies]
+actix-rt = "1.0"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ CRATES=$(dir $(wildcard **/Cargo.toml))
 
 define run_on_crates
 	failed=false; \
+	echo '<base>'; \
+	cargo $(1) $(EXTRA) || failed=true; \
 	for dir in $(CRATES); do \
 		echo "$$dir"; \
 		cd "$$dir"; \

--- a/README.md
+++ b/README.md
@@ -6,33 +6,145 @@
 
 Dependency Injection in Rust
 
-This crate provides integration support between `coi` and `actix-web`.
+This crate provides integration support between `coi` and `actix-web`. It
+exposes an `inject` procedural attribute macro to generate the code for
+retrieving your dependencies from a `Container` registered with `actix-web`.
 
 ## Example
 
-In your `Cargo.toml`
-```toml
-[dependencies]
-coi = { package = "coi-actix-web", version = "0.4.0" }
-```
-
-> ### Note
-> It's important to rename the package to `coi` since it re-exports proc-macros from the `coi` crate, which expects the crate to be named `coi`.
-
-and in your code:
-
 ```rust
-use coi::inject;
-...
+// What this crate provides
+use coi_actix_web::inject;
 
-#[inject]
-async get_all(#[inject] service: Arc<dyn IService>) -> Result<impl Responder, ()> {
-    let name = service.get(*id).await.map_err(|e| log::error!("{}", e))?;
-    Ok(HttpResponse::Ok().json(DataDto::from(name)))
+// What's needed for the example fn below
+use actix_web::{get, web::{self, HttpResponse}, Responder};
+use std::sync::Arc;
+
+// Add the `inject` attribute to the function you want to inject
+#[get("/{id}")]
+#[coi_actix_web::inject]
+async fn get(
+    id: web::Path<u64>,
+    // Add the `inject` field attribute to each attribute you want
+    // injected
+    #[inject] service: Arc<dyn IService>
+) -> Result<impl Responder, ()> {
+    let data = service.get(*id).await?;
+    Ok(HttpResponse::Ok().json(DataDto::from(data)))
+}
+
+// Just data models for the above fn
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct DataDto {
+    name: String,
+}
+
+impl DataDto {
+    fn from(data: Data) -> Self {
+        Self {
+            name: data.name
+        }
+    }
+}
+
+
+// An example of what's usually needed to make effective use of this
+// crate is below
+use coi::Inject;
+use futures::future::{ready, BoxFuture};
+
+// This section shows coi being put to use
+// It's very important that the version of coi and the version
+// of coi-actix-web used match since coi-actix-web implements
+// some coi traits
+
+// Here we're marking a trait as injectable
+trait IService: Inject {
+    fn get(&self, id: u64) -> BoxFuture<Result<Data, ()>>;
+}
+
+// And here we're marking a type that's capable of providing the
+// above trait
+#[derive(Inject)]
+#[coi(provides dyn IService with ServiceImpl::new(repo))]
+struct ServiceImpl {
+    // Here we're injecting a dependency. `ServiceImpl` does
+    // not need to know how to get this value.
+    #[coi(inject)]
+    repo: Arc<dyn IRepo>
+}
+
+// Normal impl for struct
+impl ServiceImpl {
+    fn new(repo: Arc<dyn IRepo>) -> Self {
+        Self { repo }
+    }
+}
+
+// Normal impl of trait for struct
+impl IService for ServiceImpl {
+    fn get(&self, id: u64) -> BoxFuture<Result<Data, ()>> {
+        self.repo.read_from_db(id)
+    }
+}
+
+// The data that will be passed between services
+struct Data {
+    id: u64,
+    name: String,
+}
+
+// Here's the trait from above
+trait IRepo: Inject {
+    fn read_from_db(&self, id: u64) -> BoxFuture<Result<Data, ()>>;
+}
+
+// And it's setup below
+#[derive(Inject)]
+#[coi(provides dyn IRepo with RepoImpl)]
+struct RepoImpl;
+
+impl IRepo for RepoImpl {
+    fn read_from_db(&self, id: u64) -> BoxFuture<Result<Data, ()>> {
+        Box::pin(ready(Ok(Data {
+            id,
+            name: format!("{}'s name...", id)
+        })))
+    }
+}
+
+// This is for the register_container function
+use coi_actix_web::AppExt as _;
+
+// Your general server setup in "main". The name here is different
+#[actix_rt::main]
+async fn like_main() -> std::io::Result<()> {
+    use actix_web::{App, HttpServer};
+    use coi::container;
+
+    // Construct your coi container with your keys and providers
+    // See the coi crate for more details
+    let container = container!{
+        repo => RepoImplProvider; scoped,
+        service => ServiceImplProvider; scoped
+    };
+
+    HttpServer::new(move || {
+        App::new()
+        // Don't forget to register the container or else
+        // the injections will fail on every request!
+        .register_container(container.clone())
+        .service(get)
+    })
+    .bind("127.0.0.1:8000")?
+    .run()
+    .await
 }
 ```
 
-See [`coi-actix-sample`] for a more involved example.
+See the repo [`coi-actix-sample`] for a more involved example.
 
 [`coi-actix-sample`]: https://github.com/Nashenas88/coi-actix-sample
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ retrieving your dependencies from a `Container` registered with `actix-web`.
 
 ## Example
 
-```rust
+```rust,no_run
 // What this crate provides
 use coi_actix_web::inject;
 
@@ -120,7 +120,7 @@ use coi_actix_web::AppExt as _;
 
 // Your general server setup in "main". The name here is different
 #[actix_rt::main]
-async fn like_main() -> std::io::Result<()> {
+async fn main() -> std::io::Result<()> {
     use actix_web::{App, HttpServer};
     use coi::container;
 

--- a/coi-actix-web-derive/Cargo.toml
+++ b/coi-actix-web-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coi-actix-web-derive"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Paul Daniel Faria <Nashenas88@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -12,11 +12,11 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.14", features = ["full"] }
-quote = "1.0.2"
-proc-macro2 = "1.0.8"
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 actix-web = "2.0"
-coi = { version = "0.9" }
+coi = { version = "0.9.1" }
 coi-actix-web = { path = ".." }

--- a/coi-actix-web-derive/Cargo.toml
+++ b/coi-actix-web-derive/Cargo.toml
@@ -15,3 +15,8 @@ proc-macro = true
 syn = { version = "1.0.14", features = ["full"] }
 quote = "1.0.2"
 proc-macro2 = "1.0.8"
+
+[dev-dependencies]
+actix-web = "2.0"
+coi = { version = "0.8" }
+coi-actix-web = { path = ".." }

--- a/coi-actix-web-derive/Cargo.toml
+++ b/coi-actix-web-derive/Cargo.toml
@@ -18,5 +18,5 @@ proc-macro2 = "1.0.8"
 
 [dev-dependencies]
 actix-web = "2.0"
-coi = { version = "0.8" }
+coi = { version = "0.9" }
 coi-actix-web = { path = ".." }

--- a/coi-actix-web-derive/src/attr.rs
+++ b/coi-actix-web-derive/src/attr.rs
@@ -1,0 +1,30 @@
+use crate::symbols::CRATE;
+use syn::{parse::{Parse, ParseStream}, parse_quote, Error, Ident, Path, Token};
+
+pub struct Inject {
+    pub crate_path: Path
+}
+
+impl Parse for Inject {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(Self {
+                crate_path: parse_quote!{::coi_actix_web}
+            });
+        }
+        let ident: Ident = input.parse()?;
+        if ident != CRATE {
+            return Err(Error::new(input.span(), "expected `crate` or no params"));
+        }
+
+        let _eq: Token![=] = input.parse()?;
+        let crate_path = input.parse()?;
+        if input.is_empty() {
+            Ok(Self {
+                crate_path
+            })
+        } else {
+            Err(Error::new(input.span(), "unexpected tokens at the end of crate field attribute"))
+        }
+    }
+}

--- a/coi-actix-web-derive/src/lib.rs
+++ b/coi-actix-web-derive/src/lib.rs
@@ -45,12 +45,17 @@ fn get_arc_ty(ty: &Type, type_path: &TypePath) -> Result<Type> {
 /// [`actix-web`]: https://docs.rs/actix-web
 ///
 /// ## Examples
-/// ```rust
+/// ```rust,no_run
+/// use actix_web::Responder;
+/// use coi::Inject;
 /// use coi_actix_web::inject;
+///
+/// # trait IService : Inject {}
 ///
 /// #[inject]
 /// async fn get_all(#[inject] service: Arc<dyn IService>) -> Result<impl Responder, ()> {
-///     ...
+///     //...
+///     Ok("Hello, World")
 /// }
 /// ```
 ///

--- a/coi-actix-web-derive/src/lib.rs
+++ b/coi-actix-web-derive/src/lib.rs
@@ -3,12 +3,16 @@
 //! [`coi-actix-web`]: https://docs.rs/coi-actix-web
 
 extern crate proc_macro;
+use crate::attr::Inject;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
     parse_macro_input, parse_quote, Error, FnArg, GenericArgument, Ident, ItemFn, Pat,
     PathArguments, Result, Type, TypePath,
 };
+
+mod attr;
+mod symbols;
 
 fn get_arc_ty(ty: &Type, type_path: &TypePath) -> Result<Type> {
     let make_arc_error = || Err(Error::new_spanned(ty, "only Arc<...> can be injected"));
@@ -41,8 +45,8 @@ fn get_arc_ty(ty: &Type, type_path: &TypePath) -> Result<Type> {
 /// [`actix-web`]: https://docs.rs/actix-web
 ///
 /// ## Examples
-/// ```rust,ignore
-/// use coi::inject;
+/// ```rust
+/// use coi_actix_web::inject;
 ///
 /// #[inject]
 /// async fn get_all(#[inject] service: Arc<dyn IService>) -> Result<impl Responder, ()> {
@@ -62,7 +66,10 @@ fn get_arc_ty(ty: &Type, type_path: &TypePath) -> Result<Type> {
 /// [`coi-actix-web`]: https://docs.rs/coi-actix-web
 /// [`actix-web`]: https://docs.rs/actix-web
 #[proc_macro_attribute]
-pub fn inject(_: TokenStream, input: TokenStream) -> TokenStream {
+pub fn inject(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attr = parse_macro_input!(attr as Inject);
+    let caw = attr.crate_path;
+
     let mut input = parse_macro_input!(input as ItemFn);
     let fn_ident = input.sig.ident.clone();
     let sig = &mut input.sig;
@@ -132,7 +139,7 @@ pub fn inject(_: TokenStream, input: TokenStream) -> TokenStream {
                 quote! {
                     #[allow(non_camel_case_types)]
                     struct #ident;
-                    impl coi::ContainerKey<#ty> for #ident {
+                    impl #caw::ContainerKey<#ty> for #ident {
                         const KEY: &'static str = #key_str;
                     }
                 },
@@ -144,15 +151,15 @@ pub fn inject(_: TokenStream, input: TokenStream) -> TokenStream {
     let injected_arg = if num_args > 1 {
         let injected_n = format_ident!("Injected{}", num_args);
         parse_quote! {
-            coi::#injected_n (( #(
-                coi::Injected(#key),
+            #caw::#injected_n (( #(
+                #caw::Injected(#key),
             )* _ )) :
-            coi::#injected_n<#( #ty, )* #( #container_key, )*>
+            #caw::#injected_n<#( #ty, )* #( #container_key, )*>
         }
     } else {
         parse_quote! {
-            coi::Injected(#( #key, )* _):
-            coi::Injected<#( Arc<#ty>, )* #( #container_key, )*>
+            #caw::Injected(#( #key, )* _):
+            #caw::Injected<#( ::std::sync::Arc<#ty>, )* #( #container_key, )*>
         }
     };
     inputs.push(injected_arg);

--- a/coi-actix-web-derive/src/symbols.rs
+++ b/coi-actix-web-derive/src/symbols.rs
@@ -1,0 +1,37 @@
+use std::fmt::{self, Display};
+use syn::{Ident, Path};
+
+#[derive(Copy, Clone)]
+pub struct Symbol(&'static str);
+
+pub const CRATE: Symbol = Symbol("crate");
+
+impl PartialEq<Symbol> for Ident {
+    fn eq(&self, sym: &Symbol) -> bool {
+        self == sym.0
+    }
+}
+
+impl<'a> PartialEq<Symbol> for &'a Ident {
+    fn eq(&self, sym: &Symbol) -> bool {
+        *self == sym.0
+    }
+}
+
+impl PartialEq<Symbol> for Path {
+    fn eq(&self, sym: &Symbol) -> bool {
+        self.is_ident(sym.0)
+    }
+}
+
+impl<'a> PartialEq<Symbol> for &'a Path {
+    fn eq(&self, sym: &Symbol) -> bool {
+        self.is_ident(sym.0)
+    }
+}
+
+impl Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}

--- a/readme-test/Cargo.toml
+++ b/readme-test/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "readme-test"
+version = "0.1.0"
+authors = ["Paul Daniel Faria <Nashenas88@users.noreply.github.com>"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/Nashenas88/coi-actix-web"
+publish = false
+
+[workspace]
+
+[dependencies]
+doc-comment = "0.3.1"
+
+[dev-dependencies]
+actix-rt = "1.0.0"
+actix-web = "2.0.0"
+coi-actix-web = { path = ".." }
+coi = "0.8.0"
+futures = "0.3.4"
+serde = "1.0.104"
+
+[patch.crates-io]
+coi = { path = "../../coi", version = "0.8.0" }

--- a/readme-test/Cargo.toml
+++ b/readme-test/Cargo.toml
@@ -10,15 +10,12 @@ publish = false
 [workspace]
 
 [dependencies]
-doc-comment = "0.3.1"
+doc-comment = "0.3.2"
 
 [dev-dependencies]
 actix-rt = "1.0.0"
 actix-web = "2.0.0"
 coi-actix-web = { path = ".." }
-coi = "0.8.0"
+coi = "0.9.0"
 futures = "0.3.4"
 serde = "1.0.104"
-
-[patch.crates-io]
-coi = { path = "../../coi", version = "0.8.0" }

--- a/readme-test/src/lib.rs
+++ b/readme-test/src/lib.rs
@@ -1,0 +1,3 @@
+use doc_comment::doctest;
+
+doctest!("../../README.md");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,8 @@
+#![deny(missing_docs)]
+
 //! This crate provides a simple Dependency Injection framework for `actix-web`.
 //! 
 //! ## Example
-//! 
-//! In `Cargo.toml`:
-//! ```toml
-//! [dependencies]
-//! coi = { package = "coi-actix-web", version = "0.4.0" }
-//! actix-web = "2.0.0"
-//! ```
 //! 
 //! Note that the following example is heavily minified. Files names don't really matter. For a
 //! more involved example, please see the [`coi-actix-sample`] repository.
@@ -69,9 +64,9 @@
 //! 
 //! // derive `Inject` for all structs that will provide the injectable traits.
 //! #[derive(Inject)]
-//! #[provides(pub dyn IService with Service::new(repository))]
+//! #[coi(provides pub dyn IService with Service::new(repository))]
 //! struct Service {
-//!     #[inject]
+//!     #[coi(inject)]
 //!     repository: Arc<dyn IRepository>,
 //! }
 //! 
@@ -95,14 +90,14 @@
 //! use ...::Tls;
 //! 
 //! #[derive(Inject)]
-//! #[provides(pub dyn IRepository with Repository::new(pool))]
+//! #[coi(provides pub dyn IRepository with Repository::new(pool))]
 //! struct Repository {
 //!     #[cfg(feature = "notls")]
-//!     #[inject]
+//!     #[coi(inject)]
 //!     pool: PostgresPool<NoTls>,
 //!
 //!     #[cfg(not(feature = "notls"))]
-//!     #[inject]
+//!     #[coi(inject)]
 //!     pool: PostgresPool<Tls>,
 //! }
 //! 
@@ -116,7 +111,7 @@
 //! }
 //! 
 //! #[derive(Provide)]
-//! #[provides(pub Pool<T> with Pool::new(self.0.pool))]
+//! #[coi(provides pub Pool<T> with Pool::new(self.0.pool))]
 //! struct PoolProvider<T> where T: ... {
 //!     pool: PostgresPool<T>
 //! }
@@ -133,10 +128,10 @@
 //!     web::{self, HttpResponse, ServiceConfig},
 //!     Responder,
 //! };
-//! use coi::inject;
+//! use coi_actix_web::inject;
 //! use std::sync::Arc;
 //! 
-//! #[inject]
+//! #[inject(coi_crate = "coi")]
 //! async fn get(
 //!     id: web::Path<i64>,
 //!     #[inject] service: Arc<dyn IService>,
@@ -145,7 +140,7 @@
 //!     Ok(HttpResponse::Ok().json(name))
 //! }
 //! 
-//! #[inject]
+//! #[inject(coi_crate = "coi")]
 //! async fn get_all(#[inject] service: Arc<dyn IService>) -> Result<impl Responder, ()> {
 //!     let data: Vec<String> = service.get_all().await.map_err(|e| log::error!("{}", e))?;
 //!     Ok(HttpResponse::Ok().json(data))
@@ -161,9 +156,37 @@
 //! }
 //! ```
 
-// re-export coi for convenience
-pub use coi::*;
+use actix_http::error::Error;
+use actix_service::ServiceFactory;
+use actix_web::{
+    dev::*,
+};
+
+/// Extensions to `actix-web`'s `App` struct
+pub trait AppExt {
+    /// A helper extension method to ensure the `Container` is
+    /// properly registered to work with the `inject` attribute macro.
+    fn register_container(self, container: Container) -> Self;
+}
+
+impl<S, T> AppExt for actix_web::App<S, T>
+where
+S: ServiceFactory<
+    Config = (),
+    Request = ServiceRequest,
+    Response = ServiceResponse<T>,
+    Error = Error,
+    InitError = ()
+>,
+T: MessageBody,
+{
+    fn register_container(self, container: Container) -> Self {
+        self.app_data(container)
+    }
+}
+
 pub use coi_actix_web_derive::*;
+use coi::{Inject, Container};
 
 use actix_web::{
     dev::Payload,
@@ -185,6 +208,7 @@ where
 pub struct Injected<T, K>(pub T, pub PhantomData<K>);
 
 impl<T, K> Injected<T, K> {
+    #[doc(hidden)]
     pub fn new(injected: T) -> Self {
         Self(injected, PhantomData)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,69 @@ use actix_web::{
 pub trait AppExt {
     /// A helper extension method to ensure the `Container` is
     /// properly registered to work with the `inject` attribute macro.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use coi_actix_web::AppExt as _;
+    /// 
+    /// // Your general server setup in "main". The name here is different
+    /// #[actix_rt::main]
+    /// async fn main() -> std::io::Result<()> {
+    ///     use actix_web::{App, HttpServer};
+    ///     use coi::container;
+    ///
+    ///     // Construct your coi container with your keys and providers
+    ///     // See the coi crate for more details
+    ///     let container = container!{
+    ///         service => ServiceImplProvider; scoped
+    ///     };
+    ///
+    ///     HttpServer::new(move || {
+    ///         App::new()
+    ///         .register_container(container.clone())
+    ///         // ^^^^^^^^^^^^^^^^
+    ///         .service(get)
+    ///     })
+    ///     .bind("127.0.0.1:8000")?
+    ///     .run()
+    ///     .await
+    /// }
+    /// 
+    /// # use coi::{Container, Inject, Provide};
+    /// # use std::sync::Arc;
+    /// # 
+    /// # struct ServiceImpl;
+    /// # 
+    /// # impl Inject for ServiceImpl {}
+    /// # 
+    /// # struct ServiceImplProvider;
+    /// # 
+    /// # impl Provide for ServiceImplProvider {
+    /// # 
+    /// #     type Output = ServiceImpl;
+    /// # 
+    /// #     fn provide(&self, _: &Container) -> coi::Result<Arc<Self::Output>> {
+    /// #         Ok(Arc::new(ServiceImpl))
+    /// #     }
+    /// # }
+    /// # 
+    /// # use actix_web::{get, web, HttpResponse, Responder};
+    /// # 
+    /// # // Add the `inject` attribute to the function you want to inject
+    /// # #[get("/{id}")]
+    /// # #[coi_actix_web::inject]
+    /// # async fn get(
+    /// #     id: web::Path<u64>,
+    /// #     // Add the `inject` field attribute to each attribute you want
+    /// #     // injected
+    /// #     #[inject] service: Arc<ServiceImpl>
+    /// # ) -> Result<impl Responder, ()> {
+    /// #     let _ = service;
+    /// #     Ok(HttpResponse::Ok())
+    /// # }
+    ///  
+    /// ```
     fn register_container(self, container: Container) -> Self;
 }
 


### PR DESCRIPTION
Drastically improve documentation.

Use latest version of `coi`.

No longer re-export `coi` deps. Require users to also depend on `coi` (like `serde` and `serde_json`).